### PR TITLE
selectores de año y que no se muestren los campos opcionales

### DIFF
--- a/website/forms.py
+++ b/website/forms.py
@@ -14,7 +14,7 @@ from .models import (
 )
 from django.core.validators import MaxValueValidator
 import datetime
-
+from .utils import generate_year_choices
 
 class AuthenticationFormWithInactiveUsersOkay(AuthenticationForm):
     def confirm_login_allowed(self, user):
@@ -22,7 +22,6 @@ class AuthenticationFormWithInactiveUsersOkay(AuthenticationForm):
             raise forms.ValidationError(
                 "Cuenta inactiva. Por favor, comuníquese con los administradores: sbustamante21@alumnos.utalca.cl, mlolas19@alumnos.utalca.cl, cecastillo19@alumnos.utalca.cl"
             )
-
 
 class StudentHistory(forms.ModelForm):
     NUMBER_CHOICES = [
@@ -33,7 +32,11 @@ class StudentHistory(forms.ModelForm):
     interest_type_id = forms.ModelChoiceField(
         queryset=InterestType.objects.exclude(name="AUXILIO"), required=True
     )
-    year = forms.IntegerField(required=True)
+    year = forms.ChoiceField(
+        choices=generate_year_choices(),
+        required=True,
+        label='Año'
+    )
     period = forms.ChoiceField(choices=NUMBER_CHOICES, required=True)
     student_id = forms.ModelChoiceField(
         queryset=Student.objects.all(),
@@ -155,7 +158,11 @@ class UserRegisterFormAdmin(forms.ModelForm):
 
 
 class StudentRegisterForm(forms.ModelForm):
-    admission_year = forms.IntegerField(required=True)
+    admission_year = forms.ChoiceField(
+        choices=generate_year_choices(),
+        required=True,
+        label='Año de Ingreso'
+    )
     personal_mail = forms.EmailField(required=False)
     phone_number = forms.IntegerField(required=False)
     curriculum_plan_id = forms.ModelChoiceField(
@@ -455,7 +462,11 @@ class SearchForm(forms.Form):
         queryset=InterestType.objects.all(), required=False
     )
     subject = forms.ModelChoiceField(queryset=Subject.objects.all(), required=False)
-    admission_year = forms.IntegerField(required=False, label='Año Ingreso')
+    admission_year = forms.ChoiceField(
+        choices=generate_year_choices(),
+        required=True,
+        label='Año de Ingreso'
+    )
     # se pueden agregar mas filtros...
 
 

--- a/website/templates/website/curriculum.html
+++ b/website/templates/website/curriculum.html
@@ -55,24 +55,28 @@
                   <p class="text-muted mb-0">{{user.email}}</p>
                 </div>
               </div>
-              <hr>
-              <div class="row">
-                <div class="col-sm-3">
-                  <p class="mb-0">Correo personal</p>
+              {% if user.personal_mail %}
+                <hr>
+                <div class="row">
+                  <div class="col-sm-3">
+                    <p class="mb-0">Correo personal</p>
+                  </div>
+                  <div class="col-sm-9">
+                    <p class="text-muted mb-0">{{user.personal_mail}}</p>
+                  </div>
                 </div>
-                <div class="col-sm-9">
-                  <p class="text-muted mb-0">{{user.personal_mail}}</p>
+              {% endif %}
+              {% if user.phone_number %}
+                <hr>
+                <div class="row">
+                  <div class="col-sm-3">
+                    <p class="mb-0">Celular</p>
+                  </div>
+                  <div class="col-sm-9">
+                    <p class="text-muted mb-0">{{user.phone_number}}</p>
+                  </div>
                 </div>
-              </div>
-              <hr>
-              <div class="row">
-                <div class="col-sm-3">
-                  <p class="mb-0">Celular</p>
-                </div>
-                <div class="col-sm-9">
-                  <p class="text-muted mb-0">{{user.phone_number}}</p>
-                </div>
-              </div>
+              {% endif %}
               <hr>
               <div class="row">
                 <div class="col-sm-3">

--- a/website/templates/website/profile_page.html
+++ b/website/templates/website/profile_page.html
@@ -113,24 +113,28 @@
                 </div>
               </div>
               {% if role == "Estudiante" %}
-              <hr>
-              <div class="row">
-                <div class="col-sm-3">
-                  <p class="mb-0">Correo Personal</p>
+                {% if user.personal_mail %}
+                <hr>
+                <div class="row">
+                  <div class="col-sm-3">
+                    <p class="mb-0">Correo Personal</p>
+                  </div>
+                  <div class="col-sm-9">
+                    <p class="text-muted mb-0">{{user.personal_mail}}</p>
+                  </div>
                 </div>
-                <div class="col-sm-9">
-                  <p class="text-muted mb-0">{{user.personal_mail}}</p>
+                {% endif %}
+                {% if user.phone_number %}
+                <hr>
+                <div class="row">
+                  <div class="col-sm-3">
+                    <p class="mb-0">Celular</p>
+                  </div>
+                  <div class="col-sm-9">
+                    <p class="text-muted mb-0">{{user.phone_number}}</p>
+                  </div>
                 </div>
-              </div>
-              <hr>
-              <div class="row">
-                <div class="col-sm-3">
-                  <p class="mb-0">Celular</p>
-                </div>
-                <div class="col-sm-9">
-                  <p class="text-muted mb-0">{{user.phone_number}}</p>
-                </div>
-              </div>
+                {% endif %}
               <hr>
               <div class="row">
                 <div class="col-sm-3">

--- a/website/utils.py
+++ b/website/utils.py
@@ -4,6 +4,7 @@ from django.http import HttpResponse
 from django.template.loader import get_template
 from xhtml2pdf import pisa
 from io import BytesIO
+from datetime import datetime
 
 def link_callback(uri, rel):
     """
@@ -37,3 +38,7 @@ def render_to_pdf(template_src, context_dict={}):
     if not pdf.err:
         return HttpResponse(result.getvalue(), content_type="application/pdf")
     return None
+
+def generate_year_choices(start_year=2000):
+    current_year = datetime.now().year
+    return [(year, year) for year in range(start_year, current_year + 1)]


### PR DESCRIPTION
Se cambian los input numericos por selectores de año en los formularios de usuario no admin.
En curriculum y perfil de estudiante, no se muestran los campos opcionales que no se han completado (perfil personal y numero telefonico)